### PR TITLE
Page index - separate out nav data into own table

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,10 @@
 {
    "autoload": {
       "psr-4": {
-         "Utils\\": "src/Utils",
+         "DB\\": "src/DB",
+         "HtmlFramework\\": "src/HtmlFramework",
          "Pages\\": "src/Pages",
-         "HtmlFramework\\": "src/HtmlFramework"
+         "Utils\\": "src/Utils"
       }
    },
    "require": {

--- a/src/DB/PDOConnection.php
+++ b/src/DB/PDOConnection.php
@@ -7,20 +7,13 @@ use PDOStatement;
 use Utils\SecretManager;
 
 class PDOConnection {
-   private static $pdoConnection;
-   private $pdo;
    private $secretInfo;
    /**
-    * There isn't really a good reason to make a lot of PDOConnections so
-    * we'll create one & just stick it in a static cache.
-    *
-    * Not the best behavior but it does the thing.
+    * It shouldn't matter much if we make a few connections so for now we'll
+    * just make a new PDO for every query.
     */
    public static function getConnection(): PDOConnection {
-      if (isset(self::$pdoConnection)) {
-         return self::$pdoConnection;
-      }
-      return self::$pdoConnection = new PDOConnection();
+      return new self();
    }
 
    public function fetchAll(string $sqlQuery): array {
@@ -49,13 +42,13 @@ class PDOConnection {
    }
 
    private function getPDO(): PDO {
-      if (isset($this->pdo)) {
-         return $this->pdo;
-      }
-      return $this->pdo = new PDO(
+      $pdo = new PDO(
          $this->generateSocketName(),
          $this->getSecret('dbUser'),
          $this->getSecret('dbPass')
       );
+      // Throw errors instead of returning false
+      $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+      return $pdo;
    }
 }

--- a/src/DB/PDOConnection.php
+++ b/src/DB/PDOConnection.php
@@ -1,12 +1,12 @@
 <?php declare(strict_types=1);
 
-namespace Utils;
+namespace DB;
 
 use PDO;
 use Utils\Server as ServerUtils;
 use Utils\SecretManager;
 
-class DB {
+class PDOConnection {
    private $pdo;
 
    public static function fetchPageIndexData(): array {

--- a/src/DB/PageIndex.php
+++ b/src/DB/PageIndex.php
@@ -8,26 +8,22 @@ use Utils\Server as ServerUtils;
 class PageIndex {
    public static function fetchAllRows(): array {
       if (!ServerUtils::onLiveSite()) {
-         return self::staticPageIndexData();
+         return self::staticPageIndexRows();
       }
       return self::fetchAllPageIndexRows();
    }
 
    private static function fetchAllPageIndexRows(): array {
       $sql = <<<EOT
-         SELECT `pageid`, `slug`, `nav_string`, `page_title`, `page_header`, `main_article`
+         SELECT `pageid`, `page_title`, `page_header`, `main_article`
          FROM `page_index`
-         LEFT JOIN `page_nav` USING (`pageid`)
-         ORDER BY `orderby` ASC
 EOT;
       return PDOConnection::getConnection()->fetchAll($sql);
    }
 
-   private static function staticPageIndexData(): array {
+   private static function staticPageIndexRows(): array {
       return [
          ['pageid' => 1,
-          'slug' => 'about-me',
-          'nav_string' => 'About Me',
           'page_title' => 'About Me - Website Demo',
           'page_header' => 'About Me',
           'main_article' => <<<EOT
@@ -37,8 +33,6 @@ I write code and don't have _any_ coding examples. I hope this will serve both a
 EOT
          ],
          ['pageid' => 2,
-          'slug' => 'dev',
-          'nav_string' => 'Dev',
           'page_title' => 'Dev - Website Demo',
           'page_header' => 'The Dev Environment',
           'main_article' => <<<EOT

--- a/src/DB/PageIndex.php
+++ b/src/DB/PageIndex.php
@@ -1,0 +1,52 @@
+<?php declare(strict_types=1);
+
+namespace DB;
+
+use DB\PDOConnection;
+use Utils\Server as ServerUtils;
+
+class PageIndex {
+   public static function fetchAllRows(): array {
+      if (!ServerUtils::onLiveSite()) {
+         return self::staticPageIndexData();
+      }
+      return self::fetchAllPageIndexRows();
+   }
+
+   private static function fetchAllPageIndexRows(): array {
+      $sql = <<<EOT
+         SELECT `pageid`, `slug`, `nav_string`, `page_title`, `page_header`, `main_article`
+         FROM `page_index`
+         LEFT JOIN `page_nav` USING (`pageid`)
+         ORDER BY `orderby` ASC
+EOT;
+      return PDOConnection::getConnection()->fetchAll($sql);
+   }
+
+   private static function staticPageIndexData(): array {
+      return [
+         ['pageid' => 1,
+          'slug' => 'about-me',
+          'nav_string' => 'About Me',
+          'page_title' => 'About Me - Website Demo',
+          'page_header' => 'About Me',
+          'main_article' => <<<EOT
+## This is the About Me Article!
+
+I write code and don't have _any_ coding examples. I hope this will serve both as my personal website and an example of how I write code!
+EOT
+         ],
+         ['pageid' => 2,
+          'slug' => 'dev',
+          'nav_string' => 'Dev',
+          'page_title' => 'Dev - Website Demo',
+          'page_header' => 'The Dev Environment',
+          'main_article' => <<<EOT
+## This is the Dev Article!
+
+I need a space that's pretty constant and one that's _kinda_ scratch paper. This one's the scratch paper!
+EOT
+         ],
+      ];
+   }
+}

--- a/src/DB/PageNav.php
+++ b/src/DB/PageNav.php
@@ -1,0 +1,73 @@
+<?php declare(strict_types=1);
+
+namespace DB;
+
+use DB\PDOConnection;
+use Utils\Server as ServerUtils;
+use Utils\StringUtils;
+use Pages\InvalidPageException;
+
+class PageNav {
+   /**
+    * This is a poor way of caching but the data set should always be
+    * pretty small and there's a future issue to actually do caching
+    * correcty: https://github.com/cdcline/demo-website/issues/15
+    */
+   private static $staticRowCache;
+   public const ARTICLE_PAGE_TYPE = 'ARTICLE_PAGE';
+   public const CUSTOM_TYPE = 'CUSTOM';
+
+   public static function fetchAllRows(): array {
+      if (!ServerUtils::onLiveSite()) {
+         return self::staticPageNavRows();
+      }
+      if (isset(self::$staticRowCache)) {
+         return self::$staticRowCache;
+      }
+      return self::$staticRowCache = self::fetchAllPageNavRows();
+   }
+
+   public static function getPageidFromSlug(string $slug): int {
+      foreach (self::fetchAllRows() as $row) {
+         if (StringUtils::iMatch($slug, $row['slug'])) {
+            return (int)$row['pageid'];
+         }
+      }
+      throw new InvalidPageException($slug);
+   }
+
+   private static function fetchAllPageNavRows(): array {
+      $sql = <<<EOT
+         SELECT `navid`, `type`, `slug`, `nav_string`, `pageid`, `orderby`
+         FROM `page_nav`
+         ORDER BY `orderby` ASC
+EOT;
+      return PDOConnection::getConnection()->fetchAll($sql);
+   }
+
+   private static function staticPageNavRows(): array {
+      return [
+         ['navid' => 1,
+          'type' => self::ARTICLE_PAGE_TYPE,
+          'slug' => 'about-me',
+          'nav_string' => 'About Me',
+          'pageid' => 1,
+          'orderby' => 1
+         ],
+         ['navid' => 2,
+          'type' => self::CUSTOM_TYPE,
+          'slug' => 'https://github.com/cdcline/demo-website',
+          'nav_string' => 'Resume',
+          'pageid' => NULL,
+          'orderby' => 3
+         ],
+         ['navid' => 3,
+          'type' => self::ARTICLE_PAGE_TYPE,
+          'slug' => 'dev',
+          'nav_string' => 'Dev',
+          'pageid' => 2,
+          'orderby' => 2
+         ]
+      ];
+   }
+}

--- a/src/HtmlFramework/Nav.php
+++ b/src/HtmlFramework/Nav.php
@@ -2,6 +2,7 @@
 
 namespace HtmlFramework;
 
+use DB\PageNav;
 use HtmlFramework\Element as HtmlElement;
 use HtmlFramework\Packet\NavPacket;
 
@@ -13,8 +14,8 @@ class Nav extends HtmlElement {
    protected $navData;
    private const FRAMEWORK_FILE = 'nav.phtml';
 
-   public static function fromValues(array $pageIndexRows): self {
-      $navPacket = new NavPacket($pageIndexRows);
+   public static function fromValues(): self {
+      $navPacket = new NavPacket(PageNav::fetchAllRows());
       return new self($navPacket);
    }
 

--- a/src/HtmlFramework/Packet/NavPacket.php
+++ b/src/HtmlFramework/Packet/NavPacket.php
@@ -2,24 +2,49 @@
 
 namespace HtmlFramework\Packet;
 
+use DB\PageNav;
 use HtmlFramework\Packet\PacketTrait;
+use Utils\StringUtils;
 
 class NavPacket {
    use PacketTrait;
 
-   public function __construct(array $pageIndexRows) {
-      return $this->setData('navIndexRows', $this->extractNavDataFromPageIndexRows($pageIndexRows));
+   public function __construct(array $pageNavRows) {
+      return $this->setData('navRows', $this->extractNavDataFromPageNavRows($pageNavRows));
    }
 
-   private function extractNavDataFromPageIndexRows(array $pageIndexRows): array {
+   private function extractNavDataFromPageNavRows(array $pageNavRows): array {
       $navData = [];
-      foreach ($pageIndexRows as $i => $row) {
+
+      // Can be done in MySQL too but this helps with the static data
+      array_multisort(array_column($pageNavRows, 'orderby'), SORT_ASC, $pageNavRows);
+
+      // I want some elements to mess with on the site, we'll designate them "fun"
+      $isFunRow = function($i): bool {
+         // Every 3rd nav row is fun starting with the first
+         return $i % 3 === 0;
+      };
+
+      foreach ($pageNavRows as $i => $row) {
          $navData[] = [
-            'url' => "/{$row['slug']}",
+            'url' => $this->getUrlFromPageNavRow($row),
             'display' => $row['nav_string'],
-            'isFun' => $i % 3 === 0 // Every 3rd is fun starting with the first
+            'isFun' => $isFunRow($i)
          ];
       }
+
       return $navData;
+   }
+
+   private function getUrlFromPageNavRow(array $navRow): string {
+      $customUrl = StringUtils::iMatch($navRow['type'], PageNav::CUSTOM_TYPE);
+      $slugOrUrl = $navRow['slug'];
+      // If it's a "custom url" just use whatever is in the field
+      return $customUrl ? $slugOrUrl : $this->generateUrlFromSlug($slugOrUrl);
+   }
+
+   // We'll assume all the "slug" urls are relative
+   private function generateUrlFromSlug(string $slug) {
+      return "/{$slug}";
    }
 }

--- a/src/Pages/BasePage.php
+++ b/src/Pages/BasePage.php
@@ -10,7 +10,7 @@ use HtmlFramework\Header as HtmlHeader;
 use HtmlFramework\Nav as HtmlNav;
 use HtmlFramework\Root as HtmlRoot;
 use HtmlFramework\Section as HtmlSection;
-use Utils\DB;
+use DB\PDOConnection;
 use Utils\StringUtils;
 
 abstract class BasePage {
@@ -51,7 +51,7 @@ abstract class BasePage {
          return $this->pageIndexRows;
       }
 
-      return $this->pageIndexRows = DB::fetchPageIndexData();
+      return $this->pageIndexRows = PDOConnection::fetchPageIndexData();
    }
 
    private function getRowBySlug(string $slug): array {

--- a/src/Pages/BasePage.php
+++ b/src/Pages/BasePage.php
@@ -2,6 +2,8 @@
 
 namespace Pages;
 
+use DB\PageIndex;
+use DB\PageNav;
 use HtmlFramework\Article as HtmlArticle;
 use HtmlFramework\Body as HtmlBody;
 use HtmlFramework\Footer as HtmlFooter;
@@ -10,11 +12,11 @@ use HtmlFramework\Header as HtmlHeader;
 use HtmlFramework\Nav as HtmlNav;
 use HtmlFramework\Root as HtmlRoot;
 use HtmlFramework\Section as HtmlSection;
-use DB\PageIndex;
 use Utils\StringUtils;
 
 abstract class BasePage {
    private const TEMPLATE_PATH = 'src/templates';
+   private $pageid;
    private $pageData = [];
    private $pageIndexRows;
 
@@ -37,7 +39,7 @@ abstract class BasePage {
    public function printHtml(): void {
       $htmlHead = HtmlHead::fromValues($this->getPageTitle());
       $htmlHeader = HtmlHeader::fromValues($this->getPageHeader());
-      $htmlNav = HtmlNav::fromValues($this->getPageIndexRows());
+      $htmlNav = HtmlNav::fromValues();
       $htmlArticle = HtmlArticle::fromValues($this->getPageTemplatePath(), $this->pageData, $this->getMainArticle());
       $htmlSection = HtmlSection::fromValues($htmlNav, $htmlArticle);
       $htmlFooter = HtmlFooter::fromValues();
@@ -54,25 +56,41 @@ abstract class BasePage {
       return $this->pageIndexRows = PageIndex::fetchAllRows();
    }
 
-   private function getRowBySlug(string $slug): array {
+   private function getRowByPageid(int $pageid): array {
       foreach ($this->getPageIndexRows() as $row) {
-         if (StringUtils::iMatch($row['slug'], $slug)) {
+         if ($pageid == $row['pageid']) {
             return $row;
          }
       }
       return [];
    }
 
+   /**
+    * We'd like to support multiple pages: https://github.com/cdcline/demo-website/issues/32
+    * but that requires more logic to abstract "templates" from "slugs" and we're
+    * not there yet.
+    *
+    * I'd still like to start using `pageid` for all the logic ASAP so we'll
+    * stick this little hack in until pages are made with an id & type.
+    */
+   private function getPageid(): int {
+      if (isset($this->pageid)) {
+         return $this->pageid;
+      }
+
+      return $this->pageid = PageNav::getPageidFromSlug($this->getPageSlug());
+   }
+
    private function getPageTitle(): string {
-      return $this->getRowBySlug($this->getPageSlug())['page_title'];
+      return $this->getRowByPageid($this->getPageid())['page_title'];
    }
 
    private function getPageHeader(): string {
-      return $this->getRowBySlug($this->getPageSlug())['page_header'];
+      return $this->getRowByPageid($this->getPageid())['page_header'];
    }
 
    private function getMainArticle(): string {
-      return $this->getRowBySlug($this->getPageSlug())['main_article'];
+      return $this->getRowByPageid($this->getPageid())['main_article'];
    }
 
    private function getPageTemplatePath(): string {

--- a/src/Pages/BasePage.php
+++ b/src/Pages/BasePage.php
@@ -10,7 +10,7 @@ use HtmlFramework\Header as HtmlHeader;
 use HtmlFramework\Nav as HtmlNav;
 use HtmlFramework\Root as HtmlRoot;
 use HtmlFramework\Section as HtmlSection;
-use DB\PDOConnection;
+use DB\PageIndex;
 use Utils\StringUtils;
 
 abstract class BasePage {
@@ -51,7 +51,7 @@ abstract class BasePage {
          return $this->pageIndexRows;
       }
 
-      return $this->pageIndexRows = PDOConnection::fetchPageIndexData();
+      return $this->pageIndexRows = PageIndex::fetchAllRows();
    }
 
    private function getRowBySlug(string $slug): array {

--- a/src/Pages/DevPage.php
+++ b/src/Pages/DevPage.php
@@ -4,7 +4,7 @@ namespace Pages;
 
 use Exception;
 use Pages\BasePage;
-use Utils\DB;
+use DB\PDOConnection;
 use Utils\Server as ServerUtils;
 use Utils\SecretManager;
 use Parsedown;
@@ -23,7 +23,7 @@ class DevPage extends BasePage {
       $parser = new Parsedown();
       $secret = $parser->text($secret);
       $this->setPageData('test', $secret);
-      $this->setPageData('pageInfo', DB::fetchPageIndexData());
+      $this->setPageData('pageInfo', PDOConnection::fetchPageIndexData());
    }
 
    protected function getPageTemplateName(): string {

--- a/src/Pages/DevPage.php
+++ b/src/Pages/DevPage.php
@@ -4,7 +4,7 @@ namespace Pages;
 
 use Exception;
 use Pages\BasePage;
-use DB\PDOConnection;
+use DB\PageIndex;
 use Utils\Server as ServerUtils;
 use Utils\SecretManager;
 use Parsedown;
@@ -23,7 +23,7 @@ class DevPage extends BasePage {
       $parser = new Parsedown();
       $secret = $parser->text($secret);
       $this->setPageData('test', $secret);
-      $this->setPageData('pageInfo', PDOConnection::fetchPageIndexData());
+      $this->setPageData('pageInfo', PageIndex::fetchAllRows());
    }
 
    protected function getPageTemplateName(): string {

--- a/src/Pages/InvalidPageException.php
+++ b/src/Pages/InvalidPageException.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+
+namespace Pages;
+
+use Exception;
+
+class InvalidPageExcaption extends Exception {
+   // Doesn't really matter, just making unique & not 0
+   private EXCEPTION_CODE = 1;
+   private $pageid;
+
+   /**
+    * NOTE: This should be just the $pageid but we'll be supporting the $slug for a bit
+    * while we don't really support many pages.
+    */
+   public function __construct(string $pageid) {
+      $this->pageid = $pageid;
+      parent::__construct($this->getCustomMessage(), self::EXCEPTION_CODE);
+   }
+
+   private function getCustomMessage(): string {
+      return "Invalid pageid: {$this->pageid}";
+   }
+}

--- a/src/Utils/DB.php
+++ b/src/Utils/DB.php
@@ -17,7 +17,8 @@ class DB {
       $sql = <<<EOT
          SELECT `pageid`, `slug`, `nav_string`, `page_title`, `page_header`, `main_article`
          FROM `page_index`
-         ORDER BY `pageid`
+         LEFT JOIN `page_nav` USING (`pageid`)
+         ORDER BY `orderby` ASC
 EOT;
       $db = new self();
       $pdoQuery = $db->query($sql);

--- a/src/schema/db_setup.sql
+++ b/src/schema/db_setup.sql
@@ -32,9 +32,10 @@ I need a space that's pretty constant and one that's _kinda_ scratch paper. This
 --
 CREATE TABLE `page_nav` (
    `navid` INT NOT NULL AUTO_INCREMENT,
-   `slug` VARCHAR(255) NOT NULL COMMENT 'string we use in the url',
+   `type` ENUM('ARTICLE_PAGE', 'CUSTOM') COMMENT 'Page will load page_index data; Custom will assume a custom link',
+   `slug` VARCHAR(255) NOT NULL COMMENT 'Either the string representing the page_index.pageid or a external full url',
    `nav_string` VARCHAR(255) NOT NULL COMMENT 'string show in the sidebar nav',
-   `pageid` INT DEFAULT NULL COMMENT 'Pageid should match in pay_index table; NULL values will use slug as a full url',
+   `pageid` INT DEFAULT NULL COMMENT 'Should match a value the in page_index table. ',
    `orderby` INT NOT NULL COMMENT 'Order entries will appear on the page',
    PRIMARY KEY(`navid`),
    UNIQUE KEY(`slug`),
@@ -42,8 +43,9 @@ CREATE TABLE `page_nav` (
 );
 --
 INSERT INTO `page_nav`
-(`slug`, `nav_string`, `pageid`, `orderby`)
+(`type`, `slug`, `nav_string`, `pageid`, `orderby`)
 VALUES
-('about-me', 'About Me', 1, 1),
-('dev', 'Dev', 2, 2);
+('ARTICLE_PAGE', 'about-me', 'About Me', 1, 1),
+('CUSTOM', 'https://github.com/cdcline/demo-website', 'Resume', NULL, 3),
+('ARTICLE_PAGE', 'dev', 'Dev', 2, 2);
 --

--- a/src/schema/db_setup.sql
+++ b/src/schema/db_setup.sql
@@ -2,7 +2,8 @@
 This should be the basic commands to run to setup the demo site database.
 NOTE: It assumes a fresh instance.
 */
-
+-- DROP DATABASE `demo-db`;
+--
 CREATE DATABASE `demo-db`;
 --
 USE `demo-db`;
@@ -10,23 +11,39 @@ USE `demo-db`;
 -- DROP TABLE `page_index`;
 --
 CREATE TABLE `page_index` (
-  `pageid` INT NOT NULL AUTO_INCREMENT COMMENT 'id used across tables',
-  `slug` VARCHAR(255) NOT NULL COMMENT 'string we use in the url',
-  `nav_string` VARCHAR(255) NOT NULL COMMENT 'string show in the sidebar nav',
-  `page_title` VARCHAR(255) NOT NULL COMMENT 'string use in the meta title field',
-  `page_header` VARCHAR(255) NOT NULL COMMENT 'string the user sees in the header',
-  `main_article` text NOT NULL COMMENT 'parsable text rendered and displayed at the top of the page',
-  PRIMARY KEY (`pageid`),
-  UNIQUE KEY(`slug`),
-  UNIQUE KEY(`nav_string`)
+   `pageid` INT NOT NULL AUTO_INCREMENT COMMENT 'id used across tables',
+   `page_title` VARCHAR(255) NOT NULL COMMENT 'string use in the meta title field',
+   `page_header` VARCHAR(255) NOT NULL COMMENT 'string the user sees in the header',
+   `main_article` text NOT NULL COMMENT 'parsable text rendered and displayed at the top of the page',
+   PRIMARY KEY (`pageid`)
 );
 --
 INSERT INTO `page_index`
-(`slug`, `nav_string`, `page_title`, `page_header`, `main_article`)
+(`page_title`, `page_header`, `main_article`)
 VALUES
-('about-me', 'About Me', 'About Me - Website Demo', 'About Me', "## This is the About Me Article!
+('About Me - Website Demo', 'About Me', "## This is the About Me Article!
 
 I write code and don't have _any_ coding examples. I hope this will serve both as my personal website and an example of how I write code!"),
-('dev', 'Dev', 'Dev - Website Demo', 'The Dev Environment', "## This is the Dev Article!
+('Dev - Website Demo', 'The Dev Environment', "## This is the Dev Article!
 
 I need a space that's pretty constant and one that's _kinda_ scratch paper. This one's the scratch paper!");
+--
+-- DROP TABLE `page_nav`;
+--
+CREATE TABLE `page_nav` (
+   `navid` INT NOT NULL AUTO_INCREMENT,
+   `slug` VARCHAR(255) NOT NULL COMMENT 'string we use in the url',
+   `nav_string` VARCHAR(255) NOT NULL COMMENT 'string show in the sidebar nav',
+   `pageid` INT DEFAULT NULL COMMENT 'Pageid should match in pay_index table; NULL values will use slug as a full url',
+   `orderby` INT NOT NULL COMMENT 'Order entries will appear on the page',
+   PRIMARY KEY(`navid`),
+   UNIQUE KEY(`slug`),
+   UNIQUE KEY(`nav_string`)
+);
+--
+INSERT INTO `page_nav`
+(`slug`, `nav_string`, `pageid`, `orderby`)
+VALUES
+('about-me', 'About Me', 1, 1),
+('dev', 'Dev', 2, 2);
+--

--- a/src/templates/dev.phtml
+++ b/src/templates/dev.phtml
@@ -4,13 +4,13 @@
 
 <table>
    <tr>
-      <th>Slug</th>
+      <th>Pageid</th>
       <th>Page Title</th>
       <th>Page Header</th>
    </tr>
    <?php foreach($this->getData('pageInfo') as $pageIndexRow) : ?>
       <tr>
-         <td><?= $pageIndexRow['slug'] ?></td>
+         <td><?= $pageIndexRow['pageid'] ?></td>
          <td><?= $pageIndexRow['page_title'] ?></td>
          <td><?= $pageIndexRow['page_header'] ?></td>
       </tr>

--- a/src/templates/framework/nav.phtml
+++ b/src/templates/framework/nav.phtml
@@ -1,6 +1,6 @@
 <nav>
    <ul>
-      <?php foreach ($this->getPacketData('navIndexRows') as $i => $navRow) :
+      <?php foreach ($this->getPacketData('navRows') as $i => $navRow) :
          $class = $navRow['isFun'] ? 'fun' : '';
       ?>
          <li>
@@ -9,6 +9,5 @@
             </a>
          </li>
       <?php endforeach ?>
-      <li><a href="#resume">My Resume</a></li>
    </ul>
 </nav>


### PR DESCRIPTION
## Problem
We used a simple table to get off the ground but it limits what we can do in the future.

Also we're got very simple database logic but that's going to get more complex and we want to handle that.

## Solution
By working on the [page navigation](https://github.com/cdcline/demo-website/issues/37) we can [improve the database logic](https://github.com/cdcline/demo-website/issues/28).

## Deliverable
 * The sidebar navigation should be populated by the new table
 * It should support an external link

## Estimate
4-5 hours