### PR TITLE
Support x number of page index entries

### DIFF
--- a/src/DB/DBTrait.php
+++ b/src/DB/DBTrait.php
@@ -21,12 +21,14 @@ trait DBTrait {
     * This should return a set of values matching the structure we'd get out of `fetchAllRows`.
     * Used for Dev when we don't want to worry about fetching data from elsewhere.
     */
-   abstract private static function getHardcodedRows();
+   // Boo, App deploys on 7.3 and we can't do this. Pretend like this is here.
+   // abstract private static function getHardcodedRows();
 
    /**
     * The actual query we'd like to stick in the "static cache"
     */
-   abstract private static function fetchAllRows();
+   // Boo, App deploys on 7.3 and we can't do this. Pretend like this is here.
+   // abstract private static function fetchAllRows();
 
    /**
     * This is a poor way of caching but the data set should always be

--- a/src/DB/DBTrait.php
+++ b/src/DB/DBTrait.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+
+namespace DB;
+
+use DB\PDOConnection;
+use Utils\ServerUtils;
+
+trait DBTrait {
+   private static $staticRowCache;
+
+   abstract private static function getStaticRows();
+   abstract private static function fetchAllRows();
+
+   public static function fetchAllRowsFromStaticCache(): array {
+      if ($sCache = self::getStaticCache()) {
+         return $sCache;
+      }
+      $rows = ServerUtils::useBackendDB() ? self::fetchAllRows() : self::getStaticRows();
+      return self::setStaticCache($rows);
+   }
+
+   private static function db(): PDOConnection {
+      return PDOConnection::getConnection();
+   }
+
+   /**
+    * This is a poor way of caching but the data set should always be
+    * pretty small and there's a future issue to actually do caching
+    * correcty: https://github.com/cdcline/demo-website/issues/15
+    */
+   private static function setStaticCache(array $rows): array {
+      return self::$staticRowCache = $rows;
+   }
+
+   private static function getStaticCache(): ?array {
+      return isset(self::$staticRowCache) ? self::$staticRowCache : null;
+   }
+}

--- a/src/DB/DBTrait.php
+++ b/src/DB/DBTrait.php
@@ -5,17 +5,39 @@ namespace DB;
 use DB\PDOConnection;
 use Utils\ServerUtils;
 
+/**
+ * This is a very basic trait that does a couple simple things
+ *  - Creates a "Static Cache"
+ *    - Allows us to query data from a source (MySQL or on file) then stick it
+ *      in the running processes memory so if we ask for the data again, we have
+ *      the values in the running process and don't have to go to the source again.
+ *  - Creates a small `db` function name for something larger `PDOConnection`
+ *    - It's annoying to type big words when you just want a db connection.
+ */
 trait DBTrait {
    private static $staticRowCache;
 
-   abstract private static function getStaticRows();
+   /**
+    * This should return a set of values matching the structure we'd get out of `fetchAllRows`.
+    * Used for Dev when we don't want to worry about fetching data from elsewhere.
+    */
+   abstract private static function getHardcodedRows();
+
+   /**
+    * The actual query we'd like to stick in the "static cache"
+    */
    abstract private static function fetchAllRows();
 
+   /**
+    * This is a poor way of caching but the data set should always be
+    * pretty small and there's a future issue to actually do caching
+    * correcty: https://github.com/cdcline/demo-website/issues/15
+    */
    public static function fetchAllRowsFromStaticCache(): array {
       if ($sCache = self::getStaticCache()) {
          return $sCache;
       }
-      $rows = ServerUtils::useBackendDB() ? self::fetchAllRows() : self::getStaticRows();
+      $rows = ServerUtils::useBackendDB() ? self::fetchAllRows() : self::getHardcodedRows();
       return self::setStaticCache($rows);
    }
 
@@ -23,11 +45,7 @@ trait DBTrait {
       return PDOConnection::getConnection();
    }
 
-   /**
-    * This is a poor way of caching but the data set should always be
-    * pretty small and there's a future issue to actually do caching
-    * correcty: https://github.com/cdcline/demo-website/issues/15
-    */
+
    private static function setStaticCache(array $rows): array {
       return self::$staticRowCache = $rows;
    }

--- a/src/DB/MiniArticle.php
+++ b/src/DB/MiniArticle.php
@@ -48,6 +48,7 @@ EOT;
       return $this->db()->fetchAll($sql);
    }
 
+   // NOTE: Order of the data matters, should match `fetchAllRows`
    private static function getHardcodedRows(): array {
       return [
          ['pageid' => 2,

--- a/src/DB/MiniArticle.php
+++ b/src/DB/MiniArticle.php
@@ -48,7 +48,7 @@ EOT;
       return $this->db()->fetchAll($sql);
    }
 
-   private static function getStaticRows(): array {
+   private static function getHardcodedRows(): array {
       return [
          ['pageid' => 2,
          'title' => 'Mini Article 1',

--- a/src/DB/MiniArticle.php
+++ b/src/DB/MiniArticle.php
@@ -45,7 +45,7 @@ class MiniArticle {
       JOIN `mini_article` USING (`mini_articleid`)
       GROUP BY `mini_articleid`
 EOT;
-      return $this->db()->fetchAll($sql);
+      return self::db()->fetchAll($sql);
    }
 
    // NOTE: Order of the data matters, should match `fetchAllRows`

--- a/src/DB/PageIndex.php
+++ b/src/DB/PageIndex.php
@@ -29,7 +29,7 @@ EOT;
       return self::db()->fetchAll($sql);
    }
 
-   private static function getStaticRows(): array {
+   private static function getHardcodedRows(): array {
       return [
          ['pageid' => 1,
           'page_title' => 'About Me - Website Demo',

--- a/src/DB/PageIndex.php
+++ b/src/DB/PageIndex.php
@@ -6,11 +6,11 @@ use DB\DBTrait;
 use Pages\InvalidPageException;
 
 class PageIndex {
+   use DBTrait;
+
    const DEFAULT_TYPE = 'default';
    const ABOUT_ME_TYPE = 'about-me';
    const DEV_TYPE = 'dev';
-
-   use DBTrait;
 
    public static function getTypeFromPageid(int $pageid): string {
       foreach (self::fetchAllRowsFromStaticCache() as $row) {

--- a/src/DB/PageIndex.php
+++ b/src/DB/PageIndex.php
@@ -2,30 +2,37 @@
 
 namespace DB;
 
-use DB\PDOConnection;
-use Utils\ServerUtils;
+use DB\DBTrait;
 
 class PageIndex {
-   public static function fetchAllRows(): array {
-      if (ServerUtils::useBackendDB()) {
-         return self::fetchAllPageIndexRows();
+   const DEFAULT_TYPE = 'default';
+   const DEV_TYPE = 'dev';
+
+   use DBTrait;
+
+   public static function getTypeFromPageid(int $pageid): ?string {
+      foreach (self::fetchAllRowsFromStaticCache() as $row) {
+         if ($row['pageid'] == $pageid) {
+            return $row['type'];
+         }
       }
-      return self::staticPageIndexRows();
+      return null;
    }
 
-   private static function fetchAllPageIndexRows(): array {
+   private static function fetchAllRows(): array {
       $sql = <<<EOT
          SELECT `pageid`, `page_title`, `page_header`, `main_article`
          FROM `page_index`
 EOT;
-      return PDOConnection::getConnection()->fetchAll($sql);
+      return self::db()->fetchAll($sql);
    }
 
-   private static function staticPageIndexRows(): array {
+   private static function getStaticRows(): array {
       return [
          ['pageid' => 1,
           'page_title' => 'About Me - Website Demo',
           'page_header' => 'About Me',
+          'type' => self::DEFAULT_TYPE,
           'main_article' => <<<EOT
 ## This is the About Me Article!
 
@@ -35,10 +42,31 @@ EOT
          ['pageid' => 2,
           'page_title' => 'Dev - Website Demo',
           'page_header' => 'The Dev Environment',
+          'type' => self::DEV_TYPE,
           'main_article' => <<<EOT
 ## This is the Dev Article!
 
 I need a space that's pretty constant and one that's _kinda_ scratch paper. This one's the scratch paper!
+EOT
+         ],
+         ['pageid' => 3,
+          'page_title' => 'Test 3 - Website Demo',
+          'page_header' => 'Test Page 3',
+          'type' => self::DEV_TYPE,
+          'main_article' => <<<EOT
+## This is **Test Page 3**
+
+Egestas sed tempus urna et pharetra pharetra massa massa ultricies. Neque sodales ut etiam sit amet nisl. Dictum sit amet justo donec enim diam vulputate. Morbi tincidunt augue interdum velit euismod in pellentesque massa placerat. Vulputate enim nulla aliquet porttitor. Aenean et tortor at risus viverra adipiscing. Pharetra sit amet aliquam id diam. Platea dictumst vestibulum rhoncus est pellentesque elit ullamcorper dignissim. Adipiscing at in tellus integer feugiat. Nulla facilisi cras fermentum odio eu feugiat pretium nibh. Pharetra massa massa ultricies mi quis hendrerit dolor. Purus ut faucibus pulvinar elementum integer enim neque volutpat ac.
+EOT
+         ],
+         ['pageid' => 4,
+          'page_title' => 'Test 4 - Website Demo',
+          'page_header' => 'Test Page 4',
+          'type' => self::DEFAULT_TYPE,
+          'main_article' => <<<EOT
+## This is _Test Page 4_
+
+Vulputate dignissim suspendisse in est. Amet risus nullam eget felis eget nunc lobortis. Pellentesque diam volutpat commodo sed egestas. Id leo in vitae turpis massa sed elementum tempus egestas. Nam libero justo laoreet sit amet cursus sit. Consectetur purus ut faucibus pulvinar. Laoreet suspendisse interdum consectetur libero id faucibus nisl. Laoreet non curabitur gravida arcu ac tortor dignissim convallis aenean. Viverra mauris in aliquam sem fringilla. Nibh nisl condimentum id venenatis a condimentum vitae sapien pellentesque. Ut placerat orci nulla pellentesque. Bibendum at varius vel pharetra vel turpis nunc eget lorem. Euismod quis viverra nibh cras pulvinar mattis nunc sed.
 EOT
          ],
       ];

--- a/src/DB/PageIndex.php
+++ b/src/DB/PageIndex.php
@@ -7,7 +7,7 @@ use Pages\InvalidPageException;
 
 class PageIndex {
    const DEFAULT_TYPE = 'default';
-   const ABOUT_ME_TYPE = 'about_me';
+   const ABOUT_ME_TYPE = 'about-me';
    const DEV_TYPE = 'dev';
 
    use DBTrait;

--- a/src/DB/PageIndex.php
+++ b/src/DB/PageIndex.php
@@ -23,48 +23,49 @@ class PageIndex {
 
    private static function fetchAllRows(): array {
       $sql = <<<EOT
-         SELECT `pageid`, `page_title`, `page_header`, `main_article`
+         SELECT `type`, `pageid`, `page_title`, `page_header`, `main_article`
          FROM `page_index`
 EOT;
       return self::db()->fetchAll($sql);
    }
 
+   // NOTE: Order of the data matters, should match `fetchAllRows`
    private static function getHardcodedRows(): array {
       return [
-         ['pageid' => 1,
+         ['type' => self::ABOUT_ME_TYPE,
+          'pageid' => 1,
           'page_title' => 'About Me - Website Demo',
           'page_header' => 'About Me',
-          'type' => self::ABOUT_ME_TYPE,
           'main_article' => <<<EOT
 ## This is the About Me Article!
 
 I write code and don't have _any_ coding examples. I hope this will serve both as my personal website and an example of how I write code!
 EOT
          ],
-         ['pageid' => 2,
+         ['type' => self::DEV_TYPE,
+          'pageid' => 2,
           'page_title' => 'Dev - Website Demo',
           'page_header' => 'The Dev Environment',
-          'type' => self::DEV_TYPE,
           'main_article' => <<<EOT
 ## This is the Dev Article!
 
 I need a space that's pretty constant and one that's _kinda_ scratch paper. This one's the scratch paper!
 EOT
          ],
-         ['pageid' => 3,
+         ['type' => self::DEV_TYPE,
+          'pageid' => 3,
           'page_title' => 'Test 3 - Website Demo',
           'page_header' => 'Test Page 3',
-          'type' => self::DEV_TYPE,
           'main_article' => <<<EOT
 ## This is **Test Page 3**
 
 Egestas sed tempus urna et pharetra pharetra massa massa ultricies. Neque sodales ut etiam sit amet nisl. Dictum sit amet justo donec enim diam vulputate. Morbi tincidunt augue interdum velit euismod in pellentesque massa placerat. Vulputate enim nulla aliquet porttitor. Aenean et tortor at risus viverra adipiscing. Pharetra sit amet aliquam id diam. Platea dictumst vestibulum rhoncus est pellentesque elit ullamcorper dignissim. Adipiscing at in tellus integer feugiat. Nulla facilisi cras fermentum odio eu feugiat pretium nibh. Pharetra massa massa ultricies mi quis hendrerit dolor. Purus ut faucibus pulvinar elementum integer enim neque volutpat ac.
 EOT
          ],
-         ['pageid' => 4,
+         ['type' => self::DEFAULT_TYPE,
+          'pageid' => 4,
           'page_title' => 'Test 4 - Website Demo',
           'page_header' => 'Test Page 4',
-          'type' => self::DEFAULT_TYPE,
           'main_article' => <<<EOT
 ## This is _Test Page 4_
 

--- a/src/DB/PageIndex.php
+++ b/src/DB/PageIndex.php
@@ -3,20 +3,22 @@
 namespace DB;
 
 use DB\DBTrait;
+use Pages\InvalidPageException;
 
 class PageIndex {
    const DEFAULT_TYPE = 'default';
+   const ABOUT_ME_TYPE = 'about_me';
    const DEV_TYPE = 'dev';
 
    use DBTrait;
 
-   public static function getTypeFromPageid(int $pageid): ?string {
+   public static function getTypeFromPageid(int $pageid): string {
       foreach (self::fetchAllRowsFromStaticCache() as $row) {
          if ($row['pageid'] == $pageid) {
             return $row['type'];
          }
       }
-      return null;
+      InvalidPageException::throwPageNotFound($pageid);
    }
 
    private static function fetchAllRows(): array {
@@ -32,7 +34,7 @@ EOT;
          ['pageid' => 1,
           'page_title' => 'About Me - Website Demo',
           'page_header' => 'About Me',
-          'type' => self::DEFAULT_TYPE,
+          'type' => self::ABOUT_ME_TYPE,
           'main_article' => <<<EOT
 ## This is the About Me Article!
 

--- a/src/DB/PageNav.php
+++ b/src/DB/PageNav.php
@@ -8,6 +8,7 @@ use Pages\InvalidPageException;
 
 class PageNav {
    use DBTrait;
+
    public const ARTICLE_PAGE_TYPE = 'ARTICLE_PAGE';
    public const CUSTOM_TYPE = 'CUSTOM';
 

--- a/src/DB/PageNav.php
+++ b/src/DB/PageNav.php
@@ -30,7 +30,7 @@ EOT;
       return self::db()->fetchAll($sql);
    }
 
-   private static function getStaticRows(): array {
+   private static function getHardcodedRows(): array {
       return [
          ['navid' => 1,
           'type' => self::ARTICLE_PAGE_TYPE,

--- a/src/DB/PageNav.php
+++ b/src/DB/PageNav.php
@@ -2,39 +2,17 @@
 
 namespace DB;
 
-use DB\PDOConnection;
-use Utils\ServerUtils;
+use DB\DBTrait;
 use Utils\StringUtils;
 use Pages\InvalidPageException;
 
 class PageNav {
-   private static $staticRowCache;
+   use DBTrait;
    public const ARTICLE_PAGE_TYPE = 'ARTICLE_PAGE';
    public const CUSTOM_TYPE = 'CUSTOM';
 
-   public static function fetchAllRows(): array {
-      if ($sCache = self::getStaticCache()) {
-         return $sCache;
-      }
-      $rows = ServerUtils::useBackendDB() ? self::fetchAllPageNavRows() : self::staticPageNavRows();
-      return self::setStaticCache($rows);
-   }
-
-   /**
-    * This is a poor way of caching but the data set should always be
-    * pretty small and there's a future issue to actually do caching
-    * correcty: https://github.com/cdcline/demo-website/issues/15
-    */
-   private static function setStaticCache(array $rows): array {
-      return self::$staticRowCache = $rows;
-   }
-
-   private static function getStaticCache(): ?array {
-      return isset(self::$staticRowCache) ? self::$staticRowCache : null;
-   }
-
    public static function getPageidFromSlug(string $slug): int {
-      foreach (self::fetchAllRows() as $row) {
+      foreach (self::fetchAllRowsFromStaticCache() as $row) {
          if (StringUtils::iMatch($slug, $row['slug'])) {
             return (int)$row['pageid'];
          }
@@ -42,16 +20,16 @@ class PageNav {
       throw new InvalidPageException($slug);
    }
 
-   private static function fetchAllPageNavRows(): array {
+   private static function fetchAllRows(): array {
       $sql = <<<EOT
          SELECT `navid`, `type`, `slug`, `nav_string`, `pageid`, `orderby`
          FROM `page_nav`
          ORDER BY `orderby` ASC
 EOT;
-      return PDOConnection::getConnection()->fetchAll($sql);
+      return self::db()->fetchAll($sql);
    }
 
-   private static function staticPageNavRows(): array {
+   private static function getStaticRows(): array {
       return [
          ['navid' => 1,
           'type' => self::ARTICLE_PAGE_TYPE,

--- a/src/DB/PageNav.php
+++ b/src/DB/PageNav.php
@@ -17,7 +17,7 @@ class PageNav {
             return (int)$row['pageid'];
          }
       }
-      throw new InvalidPageException($slug);
+      InvalidPageException::throwPageNotFound($slug);
    }
 
    private static function fetchAllRows(): array {

--- a/src/DB/PageNav.php
+++ b/src/DB/PageNav.php
@@ -30,6 +30,7 @@ EOT;
       return self::db()->fetchAll($sql);
    }
 
+   // NOTE: Order of the data matters, should match `fetchAllRows`
    private static function getHardcodedRows(): array {
       return [
          ['navid' => 1,

--- a/src/HtmlFramework/Article.php
+++ b/src/HtmlFramework/Article.php
@@ -20,9 +20,9 @@ use Utils\Parser;
 class Article extends HtmlElement {
    private const FRAMEWORK_FILE = 'article.phtml';
 
-   public static function fromValues(string $pageType, int $pageid, string $articlePath, array $pageData, string $mainArticle): self {
+   public static function fromValues(string $pageType, int $pageid, string $templateForPageType, array $dataForTypeTemplate, string $mainArticle): self {
       $wcPacket = WidgetCollectionPacket::fromValues($pageType, $pageid);
-      $packet = new ArticlePacket($wcPacket, $articlePath, $pageData, $mainArticle);
+      $packet = new ArticlePacket($wcPacket, $templateForPageType, $dataForTypeTemplate, $mainArticle);
       return new self($packet);
    }
 
@@ -42,12 +42,26 @@ class Article extends HtmlElement {
       return Parser::parseText($this->packet->getData('mainArticle'));
    }
 
+   protected function getHtmlForPageType(): string {
+      // Probably a better way of doing this; basically we render the template between the ob calls
+      ob_start();
+      require $this->packet->getData('templateForPageType');
+      return ob_get_clean();
+   }
+
    protected function getWidgetCollectionHtml(): string {
       return WidgetCollection::getHtmlFromArticlePacket($this->packet);
    }
 
+   /**
+    * We're gonna try to isolate the data we actually use in the "type template"
+    * through this abstraction.
+    *
+    * It's useful to know what data is specifically needed and also useful to have
+    * it in a single spot.
+    */
    protected function getData(string $index) {
-      $articleData = $this->packet->getData('articleData');
+      $articleData = $this->packet->getData('dataForTypeTemplate');
       return isset($articleData[$index]) ? $articleData[$index] : null;
    }
 }

--- a/src/HtmlFramework/Article.php
+++ b/src/HtmlFramework/Article.php
@@ -5,6 +5,7 @@ namespace HtmlFramework;
 use HtmlFramework\Element as HtmlElement;
 use HtmlFramework\Packet\ArticlePacket;
 use HtmlFramework\Widget\MiniArticleList;
+use HtmlFramework\Widget\WidgetCollection;
 use Utils\Parser;
 
 /**
@@ -18,8 +19,8 @@ use Utils\Parser;
 class Article extends HtmlElement {
    private const FRAMEWORK_FILE = 'article.phtml';
 
-   public static function fromValues(int $pageid, string $articlePath, array $pageData, string $mainArticle): self {
-      $packet = new ArticlePacket($pageid, $articlePath, $pageData, $mainArticle);
+   public static function fromValues(string $pageType, int $pageid, string $articlePath, array $pageData, string $mainArticle): self {
+      $packet = new ArticlePacket($pageType, $pageid, $articlePath, $pageData, $mainArticle);
       return new self($packet);
    }
 
@@ -35,8 +36,8 @@ class Article extends HtmlElement {
       return Parser::parseText($this->packet->getData('mainArticle'));
    }
 
-   protected function getMiniArticleList(): MiniArticleList {
-      return MiniArticleList::fromPageid($this->packet->getPageid());
+   protected function getWidgetCollectionHtml(): string {
+      return WidgetCollection::getHtml($this->packet);
    }
 
    protected function getData(string $index) {

--- a/src/HtmlFramework/Article.php
+++ b/src/HtmlFramework/Article.php
@@ -4,6 +4,7 @@ namespace HtmlFramework;
 
 use HtmlFramework\Element as HtmlElement;
 use HtmlFramework\Packet\ArticlePacket;
+use HtmlFramework\Packet\WidgetCollectionPacket;
 use HtmlFramework\Widget\MiniArticleList;
 use HtmlFramework\Widget\WidgetCollection;
 use Utils\Parser;
@@ -20,8 +21,13 @@ class Article extends HtmlElement {
    private const FRAMEWORK_FILE = 'article.phtml';
 
    public static function fromValues(string $pageType, int $pageid, string $articlePath, array $pageData, string $mainArticle): self {
-      $packet = new ArticlePacket($pageType, $pageid, $articlePath, $pageData, $mainArticle);
+      $wcPacket = WidgetCollectionPacket::fromValues($pageType, $pageid);
+      $packet = new ArticlePacket($wcPacket, $articlePath, $pageData, $mainArticle);
       return new self($packet);
+   }
+
+   public function getWidgetCollectionPacket(): WidgetCollectionPacket {
+      return $this->packet->getWidgetCollectionPacket();
    }
 
    private function __construct(ArticlePacket $packet) {
@@ -37,7 +43,7 @@ class Article extends HtmlElement {
    }
 
    protected function getWidgetCollectionHtml(): string {
-      return WidgetCollection::getHtml($this->packet);
+      return WidgetCollection::getHtmlFromArticlePacket($this->packet);
    }
 
    protected function getData(string $index) {

--- a/src/HtmlFramework/Nav.php
+++ b/src/HtmlFramework/Nav.php
@@ -15,7 +15,7 @@ class Nav extends HtmlElement {
    private const FRAMEWORK_FILE = 'nav.phtml';
 
    public static function fromValues(): self {
-      $navPacket = new NavPacket(PageNav::fetchAllRows());
+      $navPacket = new NavPacket(PageNav::fetchAllRowsFromStaticCache());
       return new self($navPacket);
    }
 

--- a/src/HtmlFramework/Packet/ArticlePacket.php
+++ b/src/HtmlFramework/Packet/ArticlePacket.php
@@ -11,14 +11,14 @@ class ArticlePacket {
    private $wcPacket;
 
    /**
-    * @param string $articlePath - Path to the phtml file we want to print
-    * @param array $pageData - Should only have the data we want to display in the article
+    * @param string $templateForPageType - Path to the phtml file we want to print for page_index.type
+    * @param array $dataForTypeTemplate - Should only have the data we want to display in the template for the given type
     * @param array $mainArticle - The main text that will be parsed into html and displayed on the page
     */
-   public function __construct(WidgetCollectionPacket $wcPacket, string $articlePath, array $articleData, string $mainArticle) {
+   public function __construct(WidgetCollectionPacket $wcPacket, string $templateForPageType, array $dataForTypeTemplate, string $mainArticle) {
       $this->wcPacket = $wcPacket;
-      $this->setData('articlePath', $articlePath);
-      $this->setData('articleData', $articleData);
+      $this->setData('templateForPageType', $templateForPageType);
+      $this->setData('dataForTypeTemplate', $dataForTypeTemplate);
       $this->setData('mainArticle', $mainArticle);
    }
 

--- a/src/HtmlFramework/Packet/ArticlePacket.php
+++ b/src/HtmlFramework/Packet/ArticlePacket.php
@@ -5,6 +5,7 @@ namespace HtmlFramework\Packet;
 use HtmlFramework\Packet\PacketTrait;
 
 class ArticlePacket {
+   private $pageType;
    private $pageid;
    use PacketTrait;
 
@@ -13,11 +14,16 @@ class ArticlePacket {
     * @param array $pageData - Should only have the data we want to display in the article
     * @param array $mainArticle - The main text that will be parsed into html and displayed on the page
     */
-   public function __construct(int $pageid, string $articlePath, array $articleData, string $mainArticle) {
+   public function __construct(string $pageType, int $pageid, string $articlePath, array $articleData, string $mainArticle) {
+      $this->pageType = $pageType;
       $this->pageid = $pageid;
       $this->setData('articlePath', $articlePath);
       $this->setData('articleData', $articleData);
       $this->setData('mainArticle', $mainArticle);
+   }
+
+   public function getPageType(): string {
+      return $this->pageType;
    }
 
    public function getPageid(): int {

--- a/src/HtmlFramework/Packet/ArticlePacket.php
+++ b/src/HtmlFramework/Packet/ArticlePacket.php
@@ -3,30 +3,34 @@
 namespace HtmlFramework\Packet;
 
 use HtmlFramework\Packet\PacketTrait;
+use HtmlFramework\Packet\WidgetCollectionPacket;
 
 class ArticlePacket {
-   private $pageType;
-   private $pageid;
    use PacketTrait;
+
+   private $wcPacket;
 
    /**
     * @param string $articlePath - Path to the phtml file we want to print
     * @param array $pageData - Should only have the data we want to display in the article
     * @param array $mainArticle - The main text that will be parsed into html and displayed on the page
     */
-   public function __construct(string $pageType, int $pageid, string $articlePath, array $articleData, string $mainArticle) {
-      $this->pageType = $pageType;
-      $this->pageid = $pageid;
+   public function __construct(WidgetCollectionPacket $wcPacket, string $articlePath, array $articleData, string $mainArticle) {
+      $this->wcPacket = $wcPacket;
       $this->setData('articlePath', $articlePath);
       $this->setData('articleData', $articleData);
       $this->setData('mainArticle', $mainArticle);
    }
 
    public function getPageType(): string {
-      return $this->pageType;
+      return $this->wcPacket->getPageType();
    }
 
    public function getPageid(): int {
-      return $this->pageid;
+      return $this->wcPacket->getPageid();
+   }
+
+   public function getWidgetCollectionPacket(): WidgetCollectionPacket {
+      return $this->wcPacket;
    }
 }

--- a/src/HtmlFramework/Packet/WidgetCollectionPacket.php
+++ b/src/HtmlFramework/Packet/WidgetCollectionPacket.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types=1);
+
+namespace HtmlFramework\Packet;
+
+use HtmlFramework\Nav as PageNav;
+use HtmlFramework\Article as PageArticle;
+use HtmlFramework\Packet\ArticlePacket;
+use HtmlFramework\Packet\PacketTrait;
+
+class WidgetCollectionPacket {
+   use PacketTrait;
+
+   private $pageType;
+   private $pageid;
+
+   public static function fromValues(string $pageType, int $pageid): self {
+      return new self($pageType, $pageid);
+   }
+
+   public function getPageType(): string {
+      return $this->pageType;
+   }
+
+   public function getPageid(): int {
+      return $this->pageid;
+   }
+
+   private function __construct(string $pageType, int $pageid) {
+      $this->pageType = $pageType;
+      $this->pageid = $pageid;
+   }
+}

--- a/src/HtmlFramework/Widget/BlockOFun.php
+++ b/src/HtmlFramework/Widget/BlockOFun.php
@@ -6,12 +6,30 @@ use Utils\HtmlUtils;
 use HtmlFramework\Packet\ArticlePacket;
 use HtmlFramework\Widget\WidgetTrait;
 
+/**
+ * Your basic block'o'fun to play with
+ *
+ * Creates something like
+ * <div class="block-o-fun">
+ *    <p>
+ *       <h1 class="fun">
+ *       <img class="fun-button">
+ *       {repeat}
+ *          {$block of text with random fun}
+ *          <br><br>
+ *       {/repeat}
+ *    </p>
+ * </div>
+ */
 class BlockOFun {
    use WidgetTrait;
 
    const FUN_IMAGE_WIDTH = 140;
    const FUN_IMAGE_HEIGHT = 140;
-   const FUN_CLASS = 'block-o-fun';
+   const FUN_CLASS = 'fun';
+   const FUN_IMG_CLASS = 'fun-btn';
+   const FUN_BLOCK_CLASS = 'block-o-fun';
+   const FUN_HEADER = 'This is your basic block of Fun!';
 
    public static function getHtmlFromArticlePacket(ArticlePacket $aPacket): string {
       return (new self())->getHtml();
@@ -19,24 +37,20 @@ class BlockOFun {
 
    public function getHtml(): string {
       $funElements = [];
-      $funElements[] = HtmlUtils::makeH1Element('This is your basic block of Fun!', 'fun');
+      $funElements[] = HtmlUtils::makeH1Element(self::FUN_HEADER, self::FUN_CLASS);
       $funElements[] = $this->makeImageElement();
       for ($i = 1; $i <= 4; $i++) {
          $funElements[] = HtmlUtils::addRandomFun($this->getText($i), rand(0, 100));
          $funElements[] = HtmlUtils::makePageWhitespace();
       }
       $fpHtml = HtmlUtils::makePElement(implode(' ', $funElements));
-      return HtmlUtils::makeDivElement($fpHtml, ['class' => 'block-o-fun']);
-   }
-
-   protected function renderWidget(): bool {
-      return true;
+      return HtmlUtils::makeDivElement($fpHtml, ['class' => self::FUN_BLOCK_CLASS]);
    }
 
    private function makeImageElement(): string {
       $picsumPhoto = HtmlUtils::getPicsumPhoto(self::FUN_IMAGE_WIDTH, self::FUN_IMAGE_HEIGHT);
       $imgAttributes = [
-         'id' => 'fun-button',
+         'class' => self::FUN_IMG_CLASS,
          'src' => $picsumPhoto,
          'width' => self::FUN_IMAGE_WIDTH,
          'height' => self::FUN_IMAGE_HEIGHT,

--- a/src/HtmlFramework/Widget/BlockOFun.php
+++ b/src/HtmlFramework/Widget/BlockOFun.php
@@ -1,0 +1,62 @@
+<?php declare(strict_types=1);
+
+namespace HtmlFramework\Widget;
+
+use Utils\HtmlUtils;
+use HtmlFramework\Widget\WidgetTrait;
+
+class BlockOFun {
+   use WidgetTrait;
+
+   const FUN_IMAGE_WIDTH = 140;
+   const FUN_IMAGE_HEIGHT = 140;
+   const FUN_CLASS = 'block-o-fun';
+
+   public function getHtml(): string {
+      $funElements = [];
+      $funElements[] = HtmlUtils::makeH1Element('This is your basic block of Fun!', 'fun');
+      $funElements[] = $this->makeImageElement();
+      for ($i = 1; $i <= 4; $i++) {
+         $funElements[] = HtmlUtils::addRandomFun($this->getText($i), rand(0, 100));
+         $funElements[] = HtmlUtils::makePageWhitespace();
+      }
+      $fpHtml = HtmlUtils::makePElement(implode(' ', $funElements));
+      return HtmlUtils::makeDivElement($fpHtml, ['class' => 'block-o-fun']);
+   }
+
+   protected function renderWidget(): bool {
+      return true;
+   }
+
+   private function makeImageElement(): string {
+      $picsumPhoto = HtmlUtils::getPicsumPhoto(self::FUN_IMAGE_WIDTH, self::FUN_IMAGE_HEIGHT);
+      $imgAttributes = [
+         'id' => 'fun-button',
+         'src' => $picsumPhoto,
+         'width' => self::FUN_IMAGE_WIDTH,
+         'height' => self::FUN_IMAGE_HEIGHT,
+         'alt' => 'random image'
+      ];
+      return HtmlUtils::makeImageElement($imgAttributes);
+   }
+
+   private function getText(int $funIndex): string {
+      switch ($funIndex) {
+         case 1: return <<<EOT
+Fermentum dui faucibus in ornare quam. Ipsum faucibus vitae aliquet nec ullamcorper sit amet risus nullam. Ut lectus arcu bibendum at. Posuere lorem ipsum dolor sit. Ultrices mi tempus imperdiet nulla malesuada. In aliquam sem fringilla ut morbi tincidunt augue interdum. Consequat semper viverra nam libero justo laoreet.
+EOT;
+         case 2: return <<<EOT
+Vitae tempus quam pellentesque nec nam aliquam sem et. A erat nam at lectus urna duis convallis convallis tellus. Nullam non nisi est sit amet. Augue lacus viverra vitae congue eu. Id diam vel quam elementum pulvinar etiam non quam. Sed viverra ipsum nunc aliquet bibendum enim facilisis gravida. In iaculis nunc sed augue lacus viverra vitae. A erat nam at lectus urna duis convallis convallis tellus.
+EOT;
+         case 3: return <<<EOT
+Curabitur pulvinar, nisl non scelerisque varius, lectus orci faucibus ante, quis condimentum quam elit vitae purus. Etiam vitae purus lacinia, convallis leo at, commodo justo. Duis sed aliquet est. Vestibulum semper justo porttitor metus ullamcorper, eu bibendum enim convallis. Nunc hendrerit venenatis libero fringilla facilisis. Duis vitae enim tristique, gravida risus at, consequat ipsum. Suspendisse vitae ipsum vel justo euismod blandit. Praesent at mollis eros, vel finibus augue. Cras lacus turpis, porttitor sed purus quis, vulputate iaculis metus. In efficitur, est ac dapibus consectetur, metus neque viverra nibh, nec aliquam nunc eros non urna. Vivamus venenatis dapibus tempor. Cras sollicitudin ante enim, sit amet pharetra ligula facilisis id. Sed tristique hendrerit mauris, at tempus lacus iaculis in. Mauris viverra vel arcu vel pellentesque.
+EOT;
+         case 4: return <<<EOT
+Donec lobortis enim quis dui auctor, et interdum purus tincidunt. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Sed quam massa, fringilla vitae lorem aliquet, vestibulum elementum ante. Vivamus sodales metus in porta hendrerit. Phasellus id cursus orci, eu dictum eros. Nulla vitae sem nec libero placerat gravida. Pellentesque scelerisque suscipit velit et convallis. Curabitur vulputate tincidunt enim, eu consectetur ipsum pretium ac.
+EOT;
+         default: return <<<EOT
+Oops. Too far!
+EOT;
+      }
+   }
+}

--- a/src/HtmlFramework/Widget/BlockOFun.php
+++ b/src/HtmlFramework/Widget/BlockOFun.php
@@ -3,6 +3,7 @@
 namespace HtmlFramework\Widget;
 
 use Utils\HtmlUtils;
+use HtmlFramework\Packet\ArticlePacket;
 use HtmlFramework\Widget\WidgetTrait;
 
 class BlockOFun {
@@ -11,6 +12,10 @@ class BlockOFun {
    const FUN_IMAGE_WIDTH = 140;
    const FUN_IMAGE_HEIGHT = 140;
    const FUN_CLASS = 'block-o-fun';
+
+   public static function getHtmlFromArticlePacket(ArticlePacket $aPacket): string {
+      return (new self())->getHtml();
+   }
 
    public function getHtml(): string {
       $funElements = [];

--- a/src/HtmlFramework/Widget/BlockOFun.php
+++ b/src/HtmlFramework/Widget/BlockOFun.php
@@ -31,11 +31,11 @@ class BlockOFun {
    const FUN_BLOCK_CLASS = 'block-o-fun';
    const FUN_HEADER = 'This is your basic block of Fun!';
 
-   public static function getHtmlFromArticlePacket(ArticlePacket $aPacket): string {
-      return (new self())->getHtml();
+   public static function getHtmlForTemplate(): string {
+      throw new Exception('Widget not supported in template');
    }
 
-   public function getHtml(): string {
+   protected function getHtml(): string {
       $funElements = [];
       $funElements[] = HtmlUtils::makeH1Element(self::FUN_HEADER, self::FUN_CLASS);
       $funElements[] = $this->makeImageElement();

--- a/src/HtmlFramework/Widget/MiniArticleList.php
+++ b/src/HtmlFramework/Widget/MiniArticleList.php
@@ -3,7 +3,7 @@
 namespace HtmlFramework\Widget;
 
 use DB\MiniArticle;
-use HtmlFramework\Packet\ArticlePacket;
+use HtmlFramework\Packet\WidgetCollectionPacket;
 use HtmlFramework\Widget\WidgetTrait;
 use Utils\HtmlUtils;
 use Utils\Parser;
@@ -11,13 +11,8 @@ use Utils\Parser;
 class MiniArticleList {
    use WidgetTrait;
 
-   private $pageid;
    private $tags;
    private $miniArticleRows;
-
-   public static function getHtmlFromArticlePacket(ArticlePacket $aPacket): string {
-      return (new self($aPacket->getPageid()))->getHtml();
-   }
 
    /**
     * Generates something like
@@ -29,16 +24,12 @@ class MiniArticleList {
     *    </div>
     * </div>
     */
-   public function getHtml(): string {
+   protected function getHtml(): string {
       if (!$this->renderWidget()) {
          return '';
       }
       $maEls = [$this->getListHeaderHtml(), $this->getListTagsHtml(), $this->getSortHtml(), $this->getMiniArticleHtml()];
       return HtmlUtils::makeDivElement(implode(' ', $maEls), ['id' => 'mini-article-list']);
-   }
-
-   private function __construct(int $pageid) {
-      $this->pageid = $pageid;
    }
 
    // I don't think I really want this in the end (the article text should suffice) but it's useful to see in dev
@@ -207,7 +198,7 @@ class MiniArticleList {
 
       // For now we'll just grab all the data and filter on pageid here.
       return $this->miniArticleRows = array_filter(MiniArticle::fetchAll(), function ($row) {
-         return $row['pageid'] == $this->pageid;
+         return $row['pageid'] == $this->wcPacket->getPageid();
       });
    }
 }

--- a/src/HtmlFramework/Widget/MiniArticleList.php
+++ b/src/HtmlFramework/Widget/MiniArticleList.php
@@ -3,9 +3,10 @@
 namespace HtmlFramework\Widget;
 
 use DB\MiniArticle;
+use HtmlFramework\Packet\ArticlePacket;
+use HtmlFramework\Widget\WidgetTrait;
 use Utils\HtmlUtils;
 use Utils\Parser;
-use HtmlFramework\Widget\WidgetTrait;
 
 class MiniArticleList {
    use WidgetTrait;
@@ -14,8 +15,8 @@ class MiniArticleList {
    private $tags;
    private $miniArticleRows;
 
-   public static function fromPageid(int $pageid): self {
-      return new self($pageid);
+   public static function getHtmlFromArticlePacket(ArticlePacket $aPacket): string {
+      return (new self($aPacket->getPageid()))->getHtml();
    }
 
    /**

--- a/src/HtmlFramework/Widget/WidgetCollection.php
+++ b/src/HtmlFramework/Widget/WidgetCollection.php
@@ -3,6 +3,7 @@
 namespace HtmlFramework\Widget;
 
 use HtmlFramework\Packet\ArticlePacket;
+use HtmlFramework\Packet\WidgetCollectionPacket;
 use HtmlFramework\Widget\BlockOFun;
 use HtmlFramework\Widget\MiniArticleList;
 use Pages\AboutMePage;
@@ -19,22 +20,23 @@ use DB\PageIndex;
  *  - Returns all the aggregated widget HTML
  */
 class WidgetCollection {
-   private $aPacket;
+   private $wcPacket;
    // By "default" we'll add all the widgets.
    private $defaultWidgets = [MiniArticleList::class, BlockOFun::class];
 
-   public static function getHtml(ArticlePacket $aPacket) {
-      return (new self($aPacket))->getAllWidgetHtml();
+   public static function getHtmlFromArticlePacket(ArticlePacket $aPacket) {
+      $wcPacket = WidgetCollectionPacket::fromValues($aPacket->getPageType(), $aPacket->getPageid());
+      return (new self($wcPacket))->getAllWidgetHtml();
    }
 
-   private function __construct(ArticlePacket $aPacket) {
-      $this->aPacket = $aPacket;
+   private function __construct(WidgetCollectionPacket $wcPacket) {
+      $this->wcPacket = $wcPacket;
    }
 
    private function getAllWidgetHtml(): string {
       $wHtml = [];
       foreach ($this->getWidgetClasses() as $wClassStr) {
-         $wHtml[] = $wClassStr::getHtmlFromArticlePacket($this->aPacket);
+         $wHtml[] = $wClassStr::getHtmlFromWidgetCollectionPacket($this->wcPacket);
       }
       return implode(' ', $wHtml);
    }
@@ -56,7 +58,7 @@ class WidgetCollection {
          return $defaultWidgets;
       };
 
-      switch ($this->aPacket->getPageType()) {
+      switch ($this->wcPacket->getPageType()) {
          case PageIndex::DEV_TYPE:
             // There's enough with the Mini Article List data on the dev page
             return $getClassesFromDefault([BlockOFun::class]);

--- a/src/HtmlFramework/Widget/WidgetCollection.php
+++ b/src/HtmlFramework/Widget/WidgetCollection.php
@@ -1,0 +1,70 @@
+<?php declare(strict_types=1);
+
+namespace HtmlFramework\Widget;
+
+use HtmlFramework\Packet\ArticlePacket;
+use HtmlFramework\Widget\BlockOFun;
+use HtmlFramework\Widget\MiniArticleList;
+use Pages\AboutMePage;
+use Pages\DefaultPage;
+use Pages\DevPage;
+use DB\PageIndex;
+
+/**
+ * Each "Page Type" can have an arbitrary number of "Widgets" linked to that type.
+ *
+ * This:
+ *  - Figures out what widgets to display
+ *  - Sending data to the Widgets
+ *  - Returns all the aggregated widget HTML
+ */
+class WidgetCollection {
+   private $aPacket;
+   // By "default" we'll add all the widgets.
+   private $defaultWidgets = [MiniArticleList::class, BlockOFun::class];
+
+   public static function getHtml(ArticlePacket $aPacket) {
+      return (new self($aPacket))->getAllWidgetHtml();
+   }
+
+   private function __construct(ArticlePacket $aPacket) {
+      $this->aPacket = $aPacket;
+   }
+
+   private function getAllWidgetHtml(): string {
+      $wHtml = [];
+      foreach ($this->getWidgetClasses() as $wClassStr) {
+         $wHtml[] = $wClassStr::getHtmlFromArticlePacket($this->aPacket);
+      }
+      return implode(' ', $wHtml);
+   }
+
+   /**
+    * Not quite sure if it's better to link class -> [widgets] here or in the
+    * Page logic but I think when it's clearer here for now.
+    *
+    * NOTE: This is probably where I'd re-order things if needed
+    */
+   private function getWidgetClasses() {
+      $getClassesFromDefault = function(array $excludeFromDefault = []): array {
+         $defaultWidgets = $this->defaultWidgets;
+         foreach ($excludeFromDefault as $className) {
+            if (($iWidget = array_search($className, $defaultWidgets)) !== false) {
+               unset($defaultWidgets[$iWidget]);
+            }
+         }
+         return $defaultWidgets;
+      };
+
+      switch ($this->aPacket->getPageType()) {
+         case PageIndex::DEV_TYPE:
+            // There's enough with the Mini Article List data on the dev page
+            return $getClassesFromDefault([BlockOFun::class]);
+         case PageIndex::ABOUT_ME_TYPE:
+            // We add the Block-O-Fun back into the template to show that you can do that
+            return $getClassesFromDefault([BlockOFun::class]);
+         default:
+            return $getClassesFromDefault();
+      }
+   }
+}

--- a/src/HtmlFramework/Widget/WidgetTrait.php
+++ b/src/HtmlFramework/Widget/WidgetTrait.php
@@ -28,6 +28,8 @@ trait WidgetTrait {
    abstract public static function getHtmlFromArticlePacket(ArticlePacket $aPacket): string;
    // It's gonna output some crazy html thing that the JS and CSS are tightly coupled with
    abstract public function getHtml(): string;
-   // We're often gonna want skip all the render logic so we'll make a common name for it while we're here
-   abstract protected function renderWidget(): bool;
+   // Sometimes we're gonna wanna skip all the render logic so we'll make a common option for that here.
+   protected function renderWidget(): bool {
+      return true;
+   };
 }

--- a/src/HtmlFramework/Widget/WidgetTrait.php
+++ b/src/HtmlFramework/Widget/WidgetTrait.php
@@ -2,6 +2,8 @@
 
 namespace HtmlFramework\Widget;
 
+use HtmlFramework\Packet\ArticlePacket;
+
 /**
  * This file is most here to talk about what a "Widget" is for this code base.
  *
@@ -20,6 +22,10 @@ namespace HtmlFramework\Widget;
  * that's what the `page_index.main_article` is for.
  */
 trait WidgetTrait {
+   // This adds some odd complexity but it's an interesting direction. It could
+   // be annoying to keep `getHtml` public in the future but for now it allows
+   // a lot of variation
+   abstract public static function getHtmlFromArticlePacket(ArticlePacket $aPacket): string;
    // It's gonna output some crazy html thing that the JS and CSS are tightly coupled with
    abstract public function getHtml(): string;
    // We're often gonna want skip all the render logic so we'll make a common name for it while we're here

--- a/src/HtmlFramework/Widget/WidgetTrait.php
+++ b/src/HtmlFramework/Widget/WidgetTrait.php
@@ -2,7 +2,7 @@
 
 namespace HtmlFramework\Widget;
 
-use HtmlFramework\Packet\ArticlePacket;
+use HtmlFramework\Packet\WidgetCollectionPacket;
 
 /**
  * This file is most here to talk about what a "Widget" is for this code base.
@@ -22,14 +22,24 @@ use HtmlFramework\Packet\ArticlePacket;
  * that's what the `page_index.main_article` is for.
  */
 trait WidgetTrait {
-   // This adds some odd complexity but it's an interesting direction. It could
-   // be annoying to keep `getHtml` public in the future but for now it allows
-   // a lot of variation
-   abstract public static function getHtmlFromArticlePacket(ArticlePacket $aPacket): string;
+   protected $wcPacket;
+
    // It's gonna output some crazy html thing that the JS and CSS are tightly coupled with
-   abstract public function getHtml(): string;
+   abstract protected function getHtml(): string;
+
+   // This adds some odd complexity but it's a fun direction.
+   public static function getHtmlFromWidgetCollectionPacket(WidgetCollectionPacket $wcPacket): string {
+      return (new self($wcPacket))->getHtml();
+   }
+
+   // We're gonna keep this private to lock down ways of adding "new" widget data
+   // Hopefully people will use the Packet instead of adding new parameters to the function
+   private function __construct(WidgetCollectionPacket $wcPacket) {
+      $this->wcPacket = $wcPacket;
+   }
+
    // Sometimes we're gonna wanna skip all the render logic so we'll make a common option for that here.
    protected function renderWidget(): bool {
       return true;
-   };
+   }
 }

--- a/src/Pages/AboutMePage.php
+++ b/src/Pages/AboutMePage.php
@@ -3,11 +3,16 @@
 namespace Pages;
 
 use Pages\BasePage;
+use DB\PageIndex;
 
-class AboutMePage extends BasePage {
+final class AboutMePage extends BasePage {
    private const PAGE_TEMPLATE = 'about_me.phtml';
 
    protected function getPageTemplateName(): string {
       return self::PAGE_TEMPLATE;
+   }
+
+   protected static function getPageType(): string {
+      return PageIndex::ABOUT_ME_TYPE;
    }
 }

--- a/src/Pages/AboutMePage.php
+++ b/src/Pages/AboutMePage.php
@@ -3,15 +3,9 @@
 namespace Pages;
 
 use Pages\BasePage;
-use Utils\ServerUtils;
 
 class AboutMePage extends BasePage {
-   private const PAGE_SLUG = 'about-me';
    private const PAGE_TEMPLATE = 'about_me.phtml';
-
-   protected function getPageSlug(): string {
-      return self::PAGE_SLUG;
-   }
 
    protected function getPageTemplateName(): string {
       return self::PAGE_TEMPLATE;

--- a/src/Pages/BasePage.php
+++ b/src/Pages/BasePage.php
@@ -22,18 +22,23 @@ abstract class BasePage {
 
    // Name of the file we'll load in the "article" section.
    abstract protected function getPageTemplateName(): string;
-   // The "Page Slug" is what we match in the url
-   abstract protected function getPageSlug(): string;
-
    // Before we print the page we might want to do stuff.
    public function doStuff(): void {}
+
+   public function __construct(int $pageid) {
+      $this->pageid = $pageid;
+   }
 
    public function setPageData(string $index, $value): void {
       $this->pageData[$index] = $value;
    }
 
-   public function matchesSlug(string $slug) {
-      return StringUtils::iMatch($this->getPageSlug(), $slug);
+   protected static function getPageType(): string {
+      return PageIndex::DEFAULT_TYPE;
+   }
+
+   public static function matchesType(string $type) {
+      return StringUtils::iMatch(static::getPageType(), $type);
    }
 
    public function printHtml(): void {
@@ -53,7 +58,7 @@ abstract class BasePage {
          return $this->pageIndexRows;
       }
 
-      return $this->pageIndexRows = PageIndex::fetchAllRows();
+      return $this->pageIndexRows = PageIndex::fetchAllRowsFromStaticCache();
    }
 
    private function getRowByPageid(int $pageid): array {

--- a/src/Pages/BasePage.php
+++ b/src/Pages/BasePage.php
@@ -56,7 +56,7 @@ abstract class BasePage {
       $htmlHead = HtmlHead::fromValues($this->getPageTitle());
       $htmlHeader = HtmlHeader::fromValues($this->getPageHeader());
       $htmlNav = HtmlNav::fromValues();
-      $htmlArticle = HtmlArticle::fromValues($this->getPageid(), $this->getPageTemplatePath(), $this->pageData, $this->getMainArticle());
+      $htmlArticle = HtmlArticle::fromValues(static::getPageType(), $this->getPageid(), $this->getPageTemplatePath(), $this->pageData, $this->getMainArticle());
       $htmlSection = HtmlSection::fromValues($htmlNav, $htmlArticle);
       $htmlFooter = HtmlFooter::fromValues();
       $htmlBody = HtmlBody::fromValues($htmlHeader, $htmlSection, $htmlFooter);

--- a/src/Pages/DefaultPage.php
+++ b/src/Pages/DefaultPage.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+
+namespace Pages;
+
+use Pages\BasePage;
+
+final class DefaultPage extends BasePage {
+   private const PAGE_TEMPLATE = 'default.phtml';
+
+   protected function getPageTemplateName(): string {
+      return self::PAGE_TEMPLATE;
+   }
+}

--- a/src/Pages/DevPage.php
+++ b/src/Pages/DevPage.php
@@ -13,7 +13,6 @@ use Utils\SecretManager;
 use Utils\StringUtils;
 
 class DevPage extends BasePage {
-   private const PAGE_SLUG = 'dev';
    private const PAGE_TEMPLATE = 'dev.phtml';
 
    public function doStuff(): void {
@@ -40,7 +39,7 @@ class DevPage extends BasePage {
       // Page Index Table
       $tPageHeader = ['Pageid', 'Page Title', 'Page Header'];
       $iPageTable = ['pageid', 'page_title', 'page_header'];
-      $tPageData = StringUtils::filterArrayByKeys(PageIndex::fetchAllRows(), $iPageTable);
+      $tPageData = StringUtils::filterArrayByKeys(PageIndex::fetchAllRowsFromStaticCache(), $iPageTable);
       return [
          'caption' => 'Page Index Rows',
          'header' => $tPageHeader,
@@ -63,7 +62,7 @@ class DevPage extends BasePage {
       return self::PAGE_TEMPLATE;
    }
 
-   protected function getPageSlug(): string {
-      return self::PAGE_SLUG;
+   protected static function getPageType(): string {
+      return PageIndex::DEV_TYPE;
    }
 }

--- a/src/Pages/DevPage.php
+++ b/src/Pages/DevPage.php
@@ -12,7 +12,7 @@ use Utils\ServerUtils;
 use Utils\SecretManager;
 use Utils\StringUtils;
 
-class DevPage extends BasePage {
+final class DevPage extends BasePage {
    private const PAGE_TEMPLATE = 'dev.phtml';
 
    public function doStuff(): void {

--- a/src/Pages/DevPage.php
+++ b/src/Pages/DevPage.php
@@ -37,8 +37,8 @@ final class DevPage extends BasePage {
 
    private function getPageIndexTableData(): array {
       // Page Index Table
-      $tPageHeader = ['Pageid', 'Page Title', 'Page Header'];
-      $iPageTable = ['pageid', 'page_title', 'page_header'];
+      $tPageHeader = ['Type', 'Pageid', 'Page Title', 'Page Header'];
+      $iPageTable = ['type', 'pageid', 'page_title', 'page_header'];
       $tPageData = StringUtils::filterArrayByKeys(PageIndex::fetchAllRowsFromStaticCache(), $iPageTable);
       return [
          'caption' => 'Page Index Rows',

--- a/src/Pages/InvalidPageException.php
+++ b/src/Pages/InvalidPageException.php
@@ -3,22 +3,32 @@
 namespace Pages;
 
 use Exception;
+use Utils\StringUtils;
 
 class InvalidPageException extends Exception {
    // Doesn't really matter, just making unique & not 0
    const EXCEPTION_CODE = 1;
-   private $pageid;
+   private $eString;
+   private $pageFindError;
 
    /**
-    * NOTE: This should be just the $pageid but we'll be supporting the $slug for a bit
-    * while we don't really support many pages.
+    * @param string|int $input - We can try to find a page by slug or pageid.
     */
-   public function __construct(string $pageid) {
-      $this->pageid = $pageid;
+   public static function throwPageNotFound($input): void {
+      throw new InvalidPageException((string)$input, /*pageFindError*/true);
+   }
+
+   public static function throwInvalidPageOperation(string $eString): void {
+      throw new InvalidPageException((string)$eString);
+   }
+
+   private function __construct(string $eString, bool $pageFindError = false) {
+      $this->eString = $eString ?: 'Warning: Blank input.';
+      $this->pageFindError = $pageFindError;
       parent::__construct($this->getCustomMessage(), self::EXCEPTION_CODE);
    }
 
    private function getCustomMessage(): string {
-      return "Invalid pageid: {$this->pageid}";
+      return $this->pageFindError ? "Unkown page: {$this->eString}" : $this->eString;
    }
 }

--- a/src/Pages/InvalidPageException.php
+++ b/src/Pages/InvalidPageException.php
@@ -4,9 +4,9 @@ namespace Pages;
 
 use Exception;
 
-class InvalidPageExcaption extends Exception {
+class InvalidPageException extends Exception {
    // Doesn't really matter, just making unique & not 0
-   private EXCEPTION_CODE = 1;
+   const EXCEPTION_CODE = 1;
    private $pageid;
 
    /**

--- a/src/Pages/PageCollection.php
+++ b/src/Pages/PageCollection.php
@@ -10,10 +10,20 @@ use Pages\AboutMePage;
 use Pages\DefaultPage;
 use Pages\DevPage;
 
+/**
+ * Basic object to setup and return a Page off of a "$slug"
+ *  - Keeps track of all "Page Types"
+ *  - Returns a Page of the correct Type for a given $pageid
+ */
 class PageCollection {
    private $pageid;
 
+   /**
+    * We call the shortened url a "slug" and here we figure out the pageid off
+    * of the slug.
+    */
    public static function getPageFromSlug(string $slug): BasePage {
+      // If it's an int looking string, assume we want to load by pageid else lookup a pageid from page_nav.slug
       $pageid = StringUtils::isInt($slug) ? (int)$slug : PageNav::getPageidFromSlug($slug);
       return (new self($pageid))->getPage();
    }
@@ -28,7 +38,7 @@ class PageCollection {
       return new $pClass($this->pageid);
    }
 
-   private function getClassFromPageType() {
+   private function getClassFromPageType(): string {
       foreach ($this->getPageTypes() as $pageType) {
          if ($pageType::matchesType($this->pageType)) {
             return $pageType;

--- a/src/Pages/PageCollection.php
+++ b/src/Pages/PageCollection.php
@@ -7,6 +7,7 @@ use DB\PageIndex;
 use Utils\StringUtils;
 use Pages\BasePage;
 use Pages\AboutMePage;
+use Pages\DefaultPage;
 use Pages\DevPage;
 
 class PageCollection {
@@ -36,6 +37,6 @@ class PageCollection {
    }
 
    private function getPageTypes(): array {
-      return [AboutMePage::class, DevPage::class];
+      return [DefaultPage::class, AboutMePage::class, DevPage::class];
    }
 }

--- a/src/Pages/PageCollection.php
+++ b/src/Pages/PageCollection.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types=1);
+
+namespace Pages;
+
+use DB\PageNav;
+use DB\PageIndex;
+use Utils\StringUtils;
+use Pages\BasePage;
+use Pages\AboutMePage;
+use Pages\DevPage;
+
+class PageCollection {
+   private $pageid;
+
+   public static function getPageFromSlug(string $slug): BasePage {
+      $pageid = StringUtils::isInt($slug) ? (int)$slug : PageNav::getPageidFromSlug($slug);
+      return (new self($pageid))->getPage();
+   }
+
+   private function __construct($pageid) {
+      $this->pageid = $pageid;
+      $this->pageType = PageIndex::getTypeFromPageid($pageid);
+   }
+
+   private function getPage(): BasePage {
+      $pClass = $this->getClassFromPageType();
+      return new $pClass($this->pageid);
+   }
+
+   private function getClassFromPageType() {
+      foreach ($this->getPageTypes() as $pageType) {
+         if ($pageType::matchesType($this->pageType)) {
+            return $pageType;
+         }
+      }
+   }
+
+   private function getPageTypes(): array {
+      return [AboutMePage::class, DevPage::class];
+   }
+}

--- a/src/Utils/HtmlUtils.php
+++ b/src/Utils/HtmlUtils.php
@@ -8,22 +8,19 @@ class HtmlUtils {
    * what you can do. There are better libraries that handle much more complicated
    * cases.
    */
-   public static function makeImageElement(string $class, string $src, int $width, int $height, string $alt, string $id = ''): string {
-      $elPartParams = [
-         'class' => $class,
-         'src' => $src,
-         'width' => $width,
-         'height' => $height,
-         'alt' => $alt,
-         'id' => $id
-      ];
-      $elPartStr = self::generateElementPartStr($elPartParams);
+   public static function makeImageElement($imgAttributes): string {
+      $elPartStr = self::generateElementPartStr($imgAttributes);
       return "<img {$elPartStr} />";
    }
 
    public static function makeDivElement(string $text, array $elPartParams = []): string {
       $elPartStr = self::generateElementPartStr($elPartParams);
       return "<div {$elPartStr}>{$text}</div>";
+   }
+
+   public static function makePElement(string $text, array $elPartParams = []): string {
+      $elPartStr = self::generateElementPartStr($elPartParams);
+      return "<p {$elPartStr}>{$text}</p>";
    }
 
    public static function makeSpanElement(string $text, array $elPartParams): string {
@@ -117,7 +114,10 @@ class HtmlUtils {
       $words = explode(' ', $text);
       $newText = [];
       $isFun = function() use ($randomizeAmount) {
-         return rand(0, $randomizeAmount) % $randomizeAmount === 0;
+         if ($randomizeAmount < 1) {
+            $randomizeAmount = 25; // arbitrary value but :shrug:
+         }
+         return rand(1, $randomizeAmount) % $randomizeAmount === 0;
       };
 
       foreach ($words as $word) {

--- a/src/Utils/SiteRunner.php
+++ b/src/Utils/SiteRunner.php
@@ -3,9 +3,10 @@
 namespace Utils;
 
 use Pages\PageCollection;
+use Pages\BasePage;
 
 class SiteRunner {
-   public static function runPage() {
+   public static function runPage(): void {
       $page = self::getPageFromUrl();
       $page->doStuff();
       $page->printHtml();
@@ -19,7 +20,7 @@ class SiteRunner {
       return substr($path, 1);
    }
 
-   private static function getPageFromUrl() {
+   private static function getPageFromUrl(): BasePage {
       return PageCollection::getPageFromSlug(self::getSlugFromUrl());
    }
 }

--- a/src/Utils/SiteRunner.php
+++ b/src/Utils/SiteRunner.php
@@ -2,9 +2,7 @@
 
 namespace Utils;
 
-use Pages\AboutMePage as AboutMePage;
-use Pages\DevPage as DevPage;
-use Utils\ServerUtils;
+use Pages\PageCollection;
 
 class SiteRunner {
    public static function runPage() {
@@ -21,24 +19,7 @@ class SiteRunner {
       return substr($path, 1);
    }
 
-   private static function getDefaultPage(): AboutMePage {
-      $aboutMeClass = AboutMePage::class;
-      return new $aboutMeClass;
-   }
-
-   private static function getAllButDefaultPages(): array {
-      $devPageClass = DevPage::class;
-      $devPage = new $devPageClass;
-      return [$devPage];
-   }
-
    private static function getPageFromUrl() {
-      $slug = self::getSlugFromUrl();
-      foreach (self::getAllButDefaultPages() as $page) {
-         if ($page->matchesSlug($slug)) {
-            return $page;
-         }
-      }
-      return self::getDefaultPage();
+      return PageCollection::getPageFromSlug(self::getSlugFromUrl());
    }
 }

--- a/src/Utils/StringUtils.php
+++ b/src/Utils/StringUtils.php
@@ -22,4 +22,8 @@ class StringUtils {
       }
       return $result;
    }
+
+   public static function isInt(string $str): bool {
+      return ctype_digit($str) && is_numeric($str);
+   }
 }

--- a/src/schema/db_setup.sql
+++ b/src/schema/db_setup.sql
@@ -12,6 +12,7 @@ USE `demo-db`;
 --
 CREATE TABLE `page_index` (
    `pageid` INT NOT NULL AUTO_INCREMENT COMMENT 'id used across tables',
+   `type` VARCHAR(255) COMMENT 'determines what page logic will run.' -- should probably be an enum but we'd like to keep the db modifications low
    `page_title` VARCHAR(255) NOT NULL COMMENT 'string use in the meta title field',
    `page_header` VARCHAR(255) NOT NULL COMMENT 'string the user sees in the header',
    `main_article` TEXT NOT NULL COMMENT 'parsable text rendered and displayed at the top of the page',
@@ -19,14 +20,20 @@ CREATE TABLE `page_index` (
 );
 --
 INSERT INTO `page_index`
-(`page_title`, `page_header`, `main_article`)
+(`page_title`, `type`, `page_header`, `main_article`)
 VALUES
-('About Me - Website Demo', 'About Me', "## This is the About Me Article!
+('About Me - Website Demo', 'about-me', 'About Me', "## This is the About Me Article!
 
 I write code and don't have _any_ coding examples. I hope this will serve both as my personal website and an example of how I write code!"),
-('Dev - Website Demo', 'The Dev Environment', "## This is the Dev Article!
+('Dev - Website Demo', 'dev', 'The Dev Environment', "## This is the Dev Article!
 
-I need a space that's pretty constant and one that's _kinda_ scratch paper. This one's the scratch paper!");
+I need a space that's pretty constant and one that's _kinda_ scratch paper. This one's the scratch paper!"),
+('Test 3 - Website Demo', 'default', 'Test Page 3', '## This is **Test Page 3**
+
+Egestas sed tempus urna et pharetra pharetra massa massa ultricies. Neque sodales ut etiam sit amet nisl. Dictum sit amet justo donec enim diam vulputate. Morbi tincidunt augue interdum velit euismod in pellentesque massa placerat. Vulputate enim nulla aliquet porttitor. Aenean et tortor at risus viverra adipiscing. Pharetra sit amet aliquam id diam. Platea dictumst vestibulum rhoncus est pellentesque elit ullamcorper dignissim. Adipiscing at in tellus integer feugiat. Nulla facilisi cras fermentum odio eu feugiat pretium nibh. Pharetra massa massa ultricies mi quis hendrerit dolor. Purus ut faucibus pulvinar elementum integer enim neque volutpat ac.'),
+('Test 4 - Website Demo', 'default', 'Test Page 4', '## This is _Test Page 4_
+
+Vulputate dignissim suspendisse in est. Amet risus nullam eget felis eget nunc lobortis. Pellentesque diam volutpat commodo sed egestas. Id leo in vitae turpis massa sed elementum tempus egestas. Nam libero justo laoreet sit amet cursus sit. Consectetur purus ut faucibus pulvinar. Laoreet suspendisse interdum consectetur libero id faucibus nisl. Laoreet non curabitur gravida arcu ac tortor dignissim convallis aenean. Viverra mauris in aliquam sem fringilla. Nibh nisl condimentum id venenatis a condimentum vitae sapien pellentesque. Ut placerat orci nulla pellentesque. Bibendum at varius vel pharetra vel turpis nunc eget lorem. Euismod quis viverra nibh cras pulvinar mattis nunc sed.');
 --
 -- DROP TABLE `page_nav`;
 --

--- a/src/schema/db_setup.sql
+++ b/src/schema/db_setup.sql
@@ -12,7 +12,7 @@ USE `demo-db`;
 --
 CREATE TABLE `page_index` (
    `pageid` INT NOT NULL AUTO_INCREMENT COMMENT 'id used across tables',
-   `type` VARCHAR(255) COMMENT 'determines what page logic will run.' -- should probably be an enum but we'd like to keep the db modifications low
+   `type` VARCHAR(255) COMMENT 'determines what page logic will run.', -- should probably be an enum but we'd like to keep the db modifications low
    `page_title` VARCHAR(255) NOT NULL COMMENT 'string use in the meta title field',
    `page_header` VARCHAR(255) NOT NULL COMMENT 'string the user sees in the header',
    `main_article` TEXT NOT NULL COMMENT 'parsable text rendered and displayed at the top of the page',

--- a/src/templates/about_me.phtml
+++ b/src/templates/about_me.phtml
@@ -17,4 +17,4 @@ $h1Text = 'This is where we can add ' . HtmlUtils::makeFunSpan('specific page el
 <p>The parsable text is <?= HtmlUtils::makeFunSpan('cool') ?> but has <?= HtmlUtils::makeFunSpan('limitations') ?></p>
 <p>This is the template where we can just <?= HtmlUtils::makeFunSpanFromArray(['do', 'random', 'things']) ?></p>
 
-<?= (new BlockOFun())->getHtml(); ?>
+<?= BlockOFun::getHtmlFromWidgetCollectionPacket($this->getWidgetCollectionPacket()) ?>

--- a/src/templates/about_me.phtml
+++ b/src/templates/about_me.phtml
@@ -1,40 +1,20 @@
 <?php
+use Utils\HtmlUtils;
+// There's no particular reason you can't just plop a widget here
+// This does require widgets logic to be more rigid but also pretty handy imo
+use HtmlFramework\Widget\BlockOFun;
+?>
+
+
+<?php
 /**
  * Using PHP to generate HTML in templates is good practice. Just don't be modifying
  * data in a Packet.
  */
-use Utils\HtmlUtils;
-
-$iWidth = $iHeight = 140;
-$randomImageElement = HtmlUtils::makeImageElement('custom-about-me-class', HtmlUtils::getPicsumPhoto($iWidth, $iHeight), $iWidth, $iHeight, 'random image', 'fun-button');
-$h1Text = 'This is where we can add ' . HtmlUtils::makeFunSpan('random widgets');
-
-$ipsumA = <<<EOT
-Fermentum dui faucibus in ornare quam. Ipsum faucibus vitae aliquet nec ullamcorper sit amet risus nullam. Ut lectus arcu bibendum at. Posuere lorem ipsum dolor sit. Ultrices mi tempus imperdiet nulla malesuada. In aliquam sem fringilla ut morbi tincidunt augue interdum. Consequat semper viverra nam libero justo laoreet.
-EOT;
-$ipsumB = <<<EOT
-Vitae tempus quam pellentesque nec nam aliquam sem et. A erat nam at lectus urna duis convallis convallis tellus. Nullam non nisi est sit amet. Augue lacus viverra vitae congue eu. Id diam vel quam elementum pulvinar etiam non quam. Sed viverra ipsum nunc aliquet bibendum enim facilisis gravida. In iaculis nunc sed augue lacus viverra vitae. A erat nam at lectus urna duis convallis convallis tellus.
-EOT;
-$ipsumC = <<<EOT
-Curabitur pulvinar, nisl non scelerisque varius, lectus orci faucibus ante, quis condimentum quam elit vitae purus. Etiam vitae purus lacinia, convallis leo at, commodo justo. Duis sed aliquet est. Vestibulum semper justo porttitor metus ullamcorper, eu bibendum enim convallis. Nunc hendrerit venenatis libero fringilla facilisis. Duis vitae enim tristique, gravida risus at, consequat ipsum. Suspendisse vitae ipsum vel justo euismod blandit. Praesent at mollis eros, vel finibus augue. Cras lacus turpis, porttitor sed purus quis, vulputate iaculis metus. In efficitur, est ac dapibus consectetur, metus neque viverra nibh, nec aliquam nunc eros non urna. Vivamus venenatis dapibus tempor. Cras sollicitudin ante enim, sit amet pharetra ligula facilisis id. Sed tristique hendrerit mauris, at tempus lacus iaculis in. Mauris viverra vel arcu vel pellentesque.
-EOT;
-$ipsumD = <<<EOT
-Donec lobortis enim quis dui auctor, et interdum purus tincidunt. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Sed quam massa, fringilla vitae lorem aliquet, vestibulum elementum ante. Vivamus sodales metus in porta hendrerit. Phasellus id cursus orci, eu dictum eros. Nulla vitae sem nec libero placerat gravida. Pellentesque scelerisque suscipit velit et convallis. Curabitur vulputate tincidunt enim, eu consectetur ipsum pretium ac.
-EOT;
-
-
+$h1Text = 'This is where we can add ' . HtmlUtils::makeFunSpan('specific page elements');
 ?>
-
 <?= HtmlUtils::makeH1Element($h1Text, 'fun') ?>
 <p>The parsable text is <?= HtmlUtils::makeFunSpan('cool') ?> but has <?= HtmlUtils::makeFunSpan('limitations') ?></p>
 <p>This is the template where we can just <?= HtmlUtils::makeFunSpanFromArray(['do', 'random', 'things']) ?></p>
-<p>
-   <?= $randomImageElement ?>
-   <?= HtmlUtils::addRandomFun($ipsumA, 100) ?>
-   <?= HtmlUtils::makePageWhitespace() ?>
-   <?= HtmlUtils::addRandomFun($ipsumB, 40) ?>
-   <?= HtmlUtils::makePageWhitespace() ?>
-   <?= HtmlUtils::addRandomFun($ipsumC, 30) ?>
-   <?= HtmlUtils::makePageWhitespace() ?>
-   <?= HtmlUtils::addRandomFun($ipsumD, 15) ?>
-</p>
+
+<?= (new BlockOFun())->getHtml(); ?>

--- a/src/templates/css/page.css
+++ b/src/templates/css/page.css
@@ -71,23 +71,26 @@ footer {
  */
 
 /**
- * About Me CSS
+ * WIDGET CSS
  */
 
- img.custom-about-me-class {
+/**
+ * Block'O'Fun CSS
+ */
+.block-o-fun img {
    border-radius: 50%;
    padding: 5px;
    margin-right: 8px;
    width: 150px;
    float: left;
- }
+}
 
  /**
   * Should be nested in above but css not complicated enough to do yet
   *
   * TODO: https://github.com/cdcline/demo-website/issues/24
   */
- img.custom-about-me-class:hover {
+.block-o-fun img:hover {
    box-shadow: 0 0 2px 1px rgba(0, 140, 186, 0.5);
    cursor: crosshair;
  }
@@ -95,7 +98,6 @@ footer {
 /**
  * Mini Article CSS
  */
-
  #mini-article-list {
     margin-top: 30px;
     display: flex;

--- a/src/templates/default.phtml
+++ b/src/templates/default.phtml
@@ -1,0 +1,1 @@
+<!-- There's no default custom text -->

--- a/src/templates/framework/article.phtml
+++ b/src/templates/framework/article.phtml
@@ -3,7 +3,7 @@
    <!-- First we display any "parsed" `page_index.main_article` html -->
    <?= $this->getParsedMainArticle() ?>
    <!-- Second we display any "page_index.page_type" html -->
-   <?php require $this->getPacketData('articlePath'); ?>
+   <?= $this->getHtmlForPageType() ?>
    <!-- Finally we display any "Widgets" we want on all the "page_index.page_type" pages -->
    <?= $this->getWidgetCollectionHtml(); ?>
 </article>

--- a/src/templates/framework/article.phtml
+++ b/src/templates/framework/article.phtml
@@ -1,5 +1,9 @@
 <article>
+   <?php /* Note: We could play with ordering more but this basic layout should handle a lot of common configurations */ ?>
+   <!-- First we display any "parsed" `page_index.main_article` html -->
    <?= $this->getParsedMainArticle() ?>
+   <!-- Second we display any "page_index.page_type" html -->
    <?php require $this->getPacketData('articlePath'); ?>
-   <?= $this->getMiniArticleList()->getHtml(); ?>
+   <!-- Finally we display any "Widgets" we want on all the "page_index.page_type" pages -->
+   <?= $this->getWidgetCollectionHtml(); ?>
 </article>

--- a/src/templates/js/page.js
+++ b/src/templates/js/page.js
@@ -48,6 +48,12 @@ class JSServerUtils {
          el.addEventListener("click", func);
       }
    }
+
+    static addClickFunctionOnClasses(className, func) {
+      [...document.getElementsByClassName(className)].forEach(function(el) {
+         el.addEventListener('click', func);
+      });
+   }
 }
 
 /**
@@ -165,7 +171,7 @@ class FunUtils {
          this.funBoom(speed);
       // Otherwise we randomize the existing colors and hope they click a few more times
       } else {
-         this.randomColorFun().bind(this);
+         this.randomColorFun();
       }
    }
 
@@ -175,7 +181,7 @@ class FunUtils {
       // Change colors after we've loaded resources. (lol js)
       JSServerUtils.addOnLoadFunction(this.randomColorFun.bind(this));
       // Start building fun with the 'fun-button'
-      JSServerUtils.addClickFunctionOnId('fun-button', this.addFun.bind(this));
+      JSServerUtils.addClickFunctionOnClasses('fun-btn', this.addFun.bind(this));
    }
 }
 


### PR DESCRIPTION
We currently only support 2 "pages" because our display logic is tied directly to the url "slug". We load `dev.phtml` when `dev` is in the url. However all the display data is in the db. We would prefer if we loaded pages off of `page_index.pageid` and displayed the data in `dev.phtml` without caring about the "slug ".

So this does that by:
 * A `page_index.type` field that we can use for display logic
 * Modifies "Page Display Logic" to be based off of `page_index.pageid` instead of `page_nav.slug`
 * Updates "page templates" to be associated with a type

Because I had extra time this also
 * Adds a new Block'O'Fun widget
 * Adds support for a set of widgets to be associated with a page type
   * Don't have to specify in the `.phtml` where they go, there's an object that manages what ones appear on what type of page